### PR TITLE
Add Flask API with OpenAI validation and CORS

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,41 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+from openai import OpenAI
+from pydantic import BaseModel, ValidationError
+import os
+
+app = Flask(__name__)
+CORS(app)
+client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+
+class Message(BaseModel):
+    role: str
+    content: str
+
+class Choice(BaseModel):
+    message: Message
+
+class CompletionResponse(BaseModel):
+    choices: list[Choice]
+
+@app.post('/complete')
+def complete():
+    data = request.get_json(force=True, silent=True) or {}
+    prompt = data.get('prompt', '')
+    if not prompt:
+        return jsonify({'error': 'prompt required'}), 400
+    try:
+        response = client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        validated = CompletionResponse.model_validate(response.model_dump())
+        content = validated.choices[0].message.content
+        return jsonify({'response': content})
+    except ValidationError:
+        return jsonify({'error': 'Invalid response structure from OpenAI'}), 502
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,4 @@
+flask
+flask-cors
+openai
+pydantic


### PR DESCRIPTION
## Summary
- add Flask endpoint wrapping OpenAI chat completion with Pydantic validation and error handling
- expose CORS-enabled `/complete` route for front-end use
- document Python dependencies

## Testing
- `python -m py_compile api/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68927be0992883328308c1daaa01afb7