### PR TITLE
Add basic Flask backend with OpenAI client

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,21 @@
+from flask import Flask
+from openai import OpenAI
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+app = Flask(__name__)
+
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key:
+    raise ValueError("OPENAI_API_KEY not set")
+
+openai_client = OpenAI(api_key=api_key)
+
+@app.route('/')
+def index():
+    return 'Backend is running'
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+flask
+openai
+python-dotenv


### PR DESCRIPTION
## Summary
- set up minimal Flask application
- load OpenAI API key from environment and initialize shared client
- document backend dependencies

## Testing
- `python backend/app.py` (fails: No module named 'flask')


------
https://chatgpt.com/codex/tasks/task_e_68927bcbac6883328e9c0f3bc7433db6