### PR TITLE
feat: connect word lookup to backend

### DIFF
--- a/components/reader/ReaderPanel.tsx
+++ b/components/reader/ReaderPanel.tsx
@@ -22,15 +22,19 @@ export default function ReaderPanel() {
   const sentences = text.split(/(?<=[.!?])\s+/);
   
   const handleWordPress = (word: string, event: any) => {
+    console.log("Word pressed:", word);
     // Get the position of the pressed word for the popover
     const { pageX, pageY } = event.nativeEvent;
+    console.log("Word position:", { x: pageX, y: pageY });
     setSelectedWordPosition({ x: pageX, y: pageY });
     handleWordLookup(word);
   };
   
   const handleSentencePress = (sentence: string, event: any) => {
+    console.log("Sentence pressed:", sentence);
     // Get the position of the pressed sentence for the popover
     const { pageX, pageY } = event.nativeEvent;
+    console.log("Sentence position:", { x: pageX, y: pageY });
     setSelectedSentencePosition({ x: pageX, y: pageY });
     handleSentenceParaphrase(sentence);
   };

--- a/components/reader/WordPopover.tsx
+++ b/components/reader/WordPopover.tsx
@@ -9,9 +9,10 @@ type WordPopoverProps = {
 };
 
 export default function WordPopover({ position }: WordPopoverProps) {
-  const { wordInfo, setActiveTool, isHeritageMode, showEnglishTranslations } = useReaderContext();
+  const { wordInfo, setActiveTool, showEnglishTranslations } = useReaderContext();
   const { getDirectionStyle } = useI18n();
-  
+
+  console.log("WordPopover: wordInfo", wordInfo);
   if (!wordInfo) return null;
   
   const handleClose = () => {
@@ -40,11 +41,11 @@ export default function WordPopover({ position }: WordPopoverProps) {
       <ScrollView style={styles.content}>
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Definition</Text>
-          <Text style={[styles.persianText, getDirectionStyle(wordInfo.definition_persian)]}>
-            {wordInfo.definition_persian}
+          <Text style={[styles.persianText, getDirectionStyle(wordInfo.definition)]}>
+            {wordInfo.definition}
           </Text>
           {showEnglishTranslations && (
-            <Text style={styles.englishText}>{wordInfo.translation_english}</Text>
+            <Text style={styles.englishText}>{wordInfo.translation}</Text>
           )}
         </View>
         
@@ -55,16 +56,16 @@ export default function WordPopover({ position }: WordPopoverProps) {
         
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Part of Speech</Text>
-          <Text style={styles.partOfSpeechText}>{wordInfo.part_of_speech}</Text>
+          <Text style={styles.partOfSpeechText}>{wordInfo.partOfSpeech}</Text>
         </View>
         
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Example</Text>
-          <Text style={[styles.persianText, getDirectionStyle(wordInfo.example_sentence_persian)]}>
-            {wordInfo.example_sentence_persian}
+          <Text style={[styles.persianText, getDirectionStyle(wordInfo.example)]}>
+            {wordInfo.example}
           </Text>
           {showEnglishTranslations && (
-            <Text style={styles.englishText}>{wordInfo.example_translation_english}</Text>
+            <Text style={styles.englishText}>{wordInfo.exampleTranslation}</Text>
           )}
         </View>
         
@@ -93,15 +94,6 @@ export default function WordPopover({ position }: WordPopoverProps) {
             ))}
           </View>
         </View>
-        
-        {isHeritageMode && (
-          <View style={styles.section}>
-            <Text style={styles.sectionTitle}>Cultural Note</Text>
-            <Text style={[styles.persianText, getDirectionStyle(wordInfo.cultural_note)]}>
-              {wordInfo.cultural_note}
-            </Text>
-          </View>
-        )}
       </ScrollView>
     </View>
   );

--- a/components/tools/WordTool.tsx
+++ b/components/tools/WordTool.tsx
@@ -4,9 +4,10 @@ import { useReaderContext } from "@/hooks/reader-context";
 import { useI18n } from "@/hooks/i18n-context";
 
 export default function WordTool() {
-  const { wordInfo, isHeritageMode, showEnglishTranslations } = useReaderContext();
+  const { wordInfo, showEnglishTranslations } = useReaderContext();
   const { getDirectionStyle } = useI18n();
-  
+
+  console.log("WordTool: wordInfo", wordInfo);
   if (!wordInfo) return null;
   
   return (
@@ -18,26 +19,26 @@ export default function WordTool() {
           {wordInfo.word}
         </Text>
         <Text style={styles.pronunciation}>{wordInfo.pronunciation}</Text>
-        <Text style={styles.partOfSpeech}>{wordInfo.part_of_speech}</Text>
+        <Text style={styles.partOfSpeech}>{wordInfo.partOfSpeech}</Text>
       </View>
       
       <View style={styles.section}>
         <Text style={styles.sectionTitle}>Definition</Text>
-        <Text style={[styles.persianText, getDirectionStyle(wordInfo.definition_persian)]}>
-          {wordInfo.definition_persian}
+        <Text style={[styles.persianText, getDirectionStyle(wordInfo.definition)]}>
+          {wordInfo.definition}
         </Text>
         {showEnglishTranslations && (
-          <Text style={styles.englishText}>{wordInfo.translation_english}</Text>
+          <Text style={styles.englishText}>{wordInfo.translation}</Text>
         )}
       </View>
       
       <View style={styles.section}>
         <Text style={styles.sectionTitle}>Example</Text>
-        <Text style={[styles.persianText, getDirectionStyle(wordInfo.example_sentence_persian)]}>
-          {wordInfo.example_sentence_persian}
+        <Text style={[styles.persianText, getDirectionStyle(wordInfo.example)]}>
+          {wordInfo.example}
         </Text>
         {showEnglishTranslations && (
-          <Text style={styles.englishText}>{wordInfo.example_translation_english}</Text>
+          <Text style={styles.englishText}>{wordInfo.exampleTranslation}</Text>
         )}
       </View>
       
@@ -66,15 +67,6 @@ export default function WordTool() {
           ))}
         </View>
       </View>
-      
-      {isHeritageMode && (
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Cultural Note</Text>
-          <Text style={[styles.persianText, getDirectionStyle(wordInfo.cultural_note)]}>
-            {wordInfo.cultural_note}
-          </Text>
-        </View>
-      )}
     </ScrollView>
   );
 }

--- a/data/index.ts
+++ b/data/index.ts
@@ -3,22 +3,21 @@
 
 export const wordLookupExample = {
   word: "نمونه",
-  definition_persian: "معنی به فارسی (برای زبان‌آموزان پیشرفته)",
-  translation_english: "example (English translation for second-language mode)",
+  definition: "معنی به فارسی (برای زبان‌آموزان پیشرفته)",
+  translation: "example (English translation for second-language mode)",
   pronunciation: "/næmuːnɛ/ (IPA notation)",
-  part_of_speech: "noun",
-  example_sentence_persian: "این یک نمونه خوب است.",
-  example_translation_english: "This is a good example.",
+  partOfSpeech: "noun",
+  example: "این یک نمونه خوب است.",
+  exampleTranslation: "This is a good example.",
   synonyms: ["مثال", "الگو"],
   antonyms: ["غیرنمونه"],
-  cultural_note: "در فرهنگ ایرانی، این کلمه اغلب در زمینه‌های آموزشی استفاده می‌شود (adjusted for heritage mode)."
 };
 
 export const sentenceParaphraseExample = {
   original_sentence: "جمله اصلی به فارسی.",
   paraphrase_persian: "جمله بازنویسی شده به فارسی ساده‌تر.",
   paraphrase_english: "English paraphrase for second-language learners.",
-  explanation: "این بازنویسی برای ساده‌سازی ساختار جمله انجام شده است، با تمرکز بر واژگان کلیدی."
+  explanation: "این بازنویسی برای ساده‌سازی ساختار جمله انجام شده است، با تمرکز بر واژگان کلیدی.",
 };
 
 export const timelineExample = [

--- a/hooks/reader-context.tsx
+++ b/hooks/reader-context.tsx
@@ -6,15 +6,14 @@ import * as mockData from "@/data";
 
 export type WordInfo = {
   word: string;
-  definition_persian: string;
-  translation_english: string;
+  definition: string;
+  translation: string;
   pronunciation: string;
-  part_of_speech: string;
-  example_sentence_persian: string;
-  example_translation_english: string;
+  partOfSpeech: string;
+  example: string;
+  exampleTranslation: string;
   synonyms: string[];
   antonyms: string[];
-  cultural_note: string;
 };
 
 export type SentenceInfo = {
@@ -131,38 +130,36 @@ export const [ReaderProvider, useReaderContext] = createContextHook(() => {
   
   // Tool handlers
   const handleWordLookup = (word: string) => {
+    console.log("handleWordLookup invoked for word:", word);
     setIsLoading(true);
     setSelectedWord(word);
     setActiveTool("wordLookup");
-    
-    // Simulate API call with mock data
-    setTimeout(() => {
-      setWordInfo(mockData.wordLookupExample);
-      setIsLoading(false);
-    }, 500);
-    
-    // In a real implementation, this would be an API call:
-    /*
-    fetch('/api/lookup', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ 
-        word, 
-        context: text, 
-        isHeritageMode 
+
+    const apiBase = process.env.EXPO_PUBLIC_API_URL || "http://localhost:3000";
+    const payload = { word, context: text, heritage_mode: isHeritageMode };
+
+    console.log("Sending lookup request to", `${apiBase}/api/lookup`, "with payload:", payload);
+
+    fetch(`${apiBase}/api/lookup`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    })
+      .then((res) => {
+        console.log("Received response from backend with status:", res.status);
+        if (!res.ok) throw new Error("Network response was not ok");
+        return res.json();
       })
-    })
-    .then(res => res.json())
-    .then(data => {
-      setWordInfo(data);
-      setIsLoading(false);
-    })
-    .catch(err => {
-      console.error(err);
-      setIsLoading(false);
-      Alert.alert('Error', 'Failed to lookup word');
-    });
-    */
+      .then((data: WordInfo) => {
+        console.log("Word lookup data received:", data);
+        setWordInfo(data);
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        console.error("Word lookup failed:", err);
+        setIsLoading(false);
+        Alert.alert("Error", "Failed to lookup word");
+      });
   };
   
   const handleSentenceParaphrase = (sentence: string) => {

--- a/server/api/lookup/route.ts
+++ b/server/api/lookup/route.ts
@@ -6,42 +6,44 @@ const OPENAI_URL = "https://api.openai.com/v1/responses";
 
 export async function POST(req: NextRequest) {
   try {
+    console.log("[lookup] Request received");
     const { word, context, heritage_mode } = await req.json();
+    console.log("[lookup] Payload:", { word, heritage_mode });
 
     if (!word) {
+      console.log("[lookup] Missing word in request");
       return NextResponse.json({ error: "Missing word" }, { status: 400 });
     }
 
-    const schema = {
-      type: "object",
-      properties: {
-        word: { type: "string" },
-        definition_persian: { type: "string" },
-        translation_english: { type: "string" },
-        pronunciation: { type: "string" },
-        part_of_speech: { type: "string" },
-        example_sentence_persian: { type: "string" },
-        example_translation_english: { type: "string" },
-        synonyms: { type: "array", items: { type: "string" } },
-        antonyms: { type: "array", items: { type: "string" } },
-        cultural_note: { type: "string" }
-      },
-      required: [
-        "word",
-        "definition_persian",
-        "translation_english",
-        "pronunciation",
-        "part_of_speech",
-        "example_sentence_persian",
-        "example_translation_english",
-        "synonyms",
-        "antonyms",
-        "cultural_note"
-      ],
-      additionalProperties: false
-    };
+      const schema = {
+        type: "object",
+        properties: {
+          word: { type: "string" },
+          definition: { type: "string" },
+          translation: { type: "string" },
+          pronunciation: { type: "string" },
+          partOfSpeech: { type: "string" },
+          example: { type: "string" },
+          exampleTranslation: { type: "string" },
+          synonyms: { type: "array", items: { type: "string" } },
+          antonyms: { type: "array", items: { type: "string" } }
+        },
+        required: [
+          "word",
+          "definition",
+          "translation",
+          "pronunciation",
+          "partOfSpeech",
+          "example",
+          "exampleTranslation",
+          "synonyms",
+          "antonyms"
+        ],
+        additionalProperties: false
+      };
 
     const prompt = `Provide detailed information for the Persian word "${word}" in the context "${context}". Heritage mode is ${heritage_mode ? "enabled" : "disabled"}.`;
+    console.log("[lookup] Generated prompt:", prompt);
 
     const body = {
       model: "o4-mini",
@@ -55,6 +57,7 @@ export async function POST(req: NextRequest) {
       }
     };
 
+    console.log("[lookup] Sending request to OpenAI");
     const aiRes = await fetch(OPENAI_URL, {
       method: "POST",
       headers: {
@@ -63,20 +66,23 @@ export async function POST(req: NextRequest) {
       },
       body: JSON.stringify(body)
     });
+    console.log("[lookup] OpenAI response status:", aiRes.status);
 
     if (!aiRes.ok) {
       const error = await aiRes.text();
-      console.error("OpenAI error", error);
+      console.error("[lookup] OpenAI error", error);
       return NextResponse.json({ error: "Failed to generate word info" }, { status: 500 });
     }
 
     const aiJson = await aiRes.json();
     const text = aiJson?.output?.[0]?.content?.[0]?.text ?? "{}";
+    console.log("[lookup] Raw OpenAI text:", text);
     const data: WordInfo = JSON.parse(text);
+    console.log("[lookup] Parsed data:", data);
 
     return NextResponse.json(data);
   } catch (err) {
-    console.error(err);
+    console.error("[lookup] Handler error", err);
     return NextResponse.json({ error: "Invalid request" }, { status: 400 });
   }
 }


### PR DESCRIPTION
## Summary
- update word lookup to fetch data from backend instead of using mock entries
- display word lookup results using new schema
- expose `/api/lookup` endpoint with strict JSON schema for word definitions
- add detailed frontend/backend logging for word lookup flow

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react-native', Cannot find module 'react', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68937a6b503483328c41a027ecb6d8d7